### PR TITLE
fix: add item placeholder image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Add item placeholder image to item page and list preview.

Fixes #2 

<img width="399" alt="Screenshot 2022-07-29 at 06 47 56" src="https://user-images.githubusercontent.com/150187/181692653-3828ac1f-c6b4-4d1e-80e4-f13f29835a03.png">

<img width="1413" alt="Screenshot 2022-07-29 at 06 48 12" src="https://user-images.githubusercontent.com/150187/181692658-3c8c3852-d2d9-4eaa-bd0c-a39d833f1728.png">



